### PR TITLE
Test with MySQL 5.7 on Travis-CI (but currently fails)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm:
 env:
   - MYSQL_VERSION=mysql-5.6
   - MYSQL_VERSION=mysql-5.7
+matrix:
+  allow_failures:
+    - env: MYSQL_VERSION=mysql-5.7
 services:
   - mysql
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,17 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+env:
+  - MYSQL_VERSION=mysql-5.6
+  - MYSQL_VERSION=mysql-5.7
+services:
+  - mysql
+before_install:
+  - gem update bundler
+  - sudo apt-get -qq update
+  - bash .travis/install_mysql.sh
+before_script:
+  - mysql --version
 script:
   - bundle install
   - bundle exec rake
-env:
-  - MYSQL_VERSION=5.6.27
-before_install:
-  - gem update bundler
-install:
-  - "sudo apt-get -y remove mysql-common mysql-server-5.5 mysql-server-core-5.5 mysql-client-5.5 mysql-client-core-5.5"
-  - "sudo apt-get -y autoremove"
-  - "sudo apt-get -y install libaio1"
-  - "wget -O mysql-$MYSQL_VERSION.deb http://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-$MYSQL_VERSION-debian6.0-x86_64.deb/from/http://cdn.mysql.com/"
-  - "sudo dpkg -i mysql-$MYSQL_VERSION.deb"
-  - "sudo cp -f /opt/mysql/server-5.6/support-files/mysql.server /etc/init.d/mysql.server"
-  - "sudo ln -sf /opt/mysql/server-5.6/bin/* /usr/bin/"
-  - "sudo sed -i'' 's/table_cache/table_open_cache/' /etc/mysql/my.cnf"
-  - "sudo sed -i'' 's/log_slow_queries/slow_query_log/' /etc/mysql/my.cnf"
-  - "sudo sed -i'' 's/basedir[^=]\\+=.*$/basedir = \\/opt\\/mysql\\/server-5.6/' /etc/mysql/my.cnf"
-  - "sudo sed -i'' 's/^socket *=.*$/socket = \\/tmp\\/mysql.sock/' /etc/mysql/my.cnf"
-  - "sudo /etc/init.d/mysql.server start"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: true
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
 env:
   - MYSQL_VERSION=mysql-5.6
   - MYSQL_VERSION=mysql-5.7

--- a/.travis/install_mysql.sh
+++ b/.travis/install_mysql.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -ex
+
+if [[ $MYSQL_VERSION =~ (mysql-5\.[67]) ]]; then
+  sudo service mysql stop
+  sudo apt-get install python-software-properties
+  cat <<EOC | sudo debconf-set-selections
+mysql-apt-config mysql-apt-config/select-server select $MYSQL_VERSION
+mysql-apt-config mysql-apt-config/repo-distro   select  ubuntu
+EOC
+  wget https://dev.mysql.com/get/mysql-apt-config_0.8.4-1_all.deb
+  sudo dpkg --install mysql-apt-config_0.8.4-1_all.deb
+  sudo apt-get update -q
+  sudo apt-get install -q -y -o Dpkg::Options::=--force-confnew mysql-server
+  sudo mysql_upgrade
+fi


### PR DESCRIPTION
@winebarrel Hi sugawara-san :hand:

I found Gratan doesn't work for MySQL 5.7. This version ([to be precise, MySQL 5.7.6](https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-6.html)) has removed `IDENTIFIED BY` from `SHOW GRANTS FOR` and moved it to `SHOW CREATE USER`.

First of all (in this PR), I made change to **test with both MySQL 5.6 and 5.7 in Travis-Ci**.

However, the test in MySQL 5.7 still fails. I plan to send patches for supporting 5.7 in another PR.

(And this PR includes supports of Ruby 2.3 or later because Ruby 2.2 or less no longer supported.)

---

`.travis/install_mysql.sh` is using [Test::mysqld](https://metacpan.org/pod/Test::mysqld) as reference:

- https://github.com/kazuho/p5-test-mysqld/blob/f2c8f2068c986b3596b615f6ce5a1c0ad9ab1c49/.travis.yml#L6-L13
- https://github.com/kazuho/p5-test-mysqld/blob/f2c8f2068c986b3596b615f6ce5a1c0ad9ab1c49/author/travis_install_mysql.sh#L14-L21