### PR TITLE
Fix env var about GRATAN_DB_DATABASE and GRATAN_DB_USERNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ A default connection to a database can be established by setting the following e
 - `GRATAN_DB_PORT`: database port
 - `GRATAN_DB_SOCKET`: database socket
 - `GRATAN_DB_DATABASE`: database database name
-- `GRATAN_DB_USER`: database user
+- `GRATAN_DB_USERNAME`: database user
 - `GRATAN_DB_PASSWORD`: database password
 
 ## Grantfile example

--- a/bin/gratan
+++ b/bin/gratan
@@ -25,7 +25,7 @@ mysql_options = {
 
 mysql_options[:socket] = ENV['GRATAN_DB_SOCKET'] if ENV['GRATAN_DB_SOCKET']
 mysql_options[:password] = ENV['GRATAN_DB_PASSWORD'] if ENV['GRATAN_DB_PASSWORD']
-mysql_options[:database] = ENV['GRATAN_DB_DATABASE'] if ENV['GRATAN_DB_PASSWORD']
+mysql_options[:database] = ENV['GRATAN_DB_DATABASE'] if ENV['GRATAN_DB_DATABASE']
 
 options = {
   :dry_run    => false,


### PR DESCRIPTION
- Fix a bug about specifying MySQL database using env variable
- Fix README about how to use GRATAN_DB_USERNAME env variable
https://github.com/codenize-tools/gratan/blob/10d55bcebe096360f1462fc1187442489f85aac8/bin/gratan#L22
